### PR TITLE
quiz in progress notification

### DIFF
--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -19,6 +19,7 @@ use Spatie\Tags\HasTags;
 use Guava\Calendar\Contracts\Eventable;
 use Guava\Calendar\ValueObjects\CalendarEvent;
 use Illuminate\Support\Collection;
+
 /**
  * @property string $id
  * @property string $title
@@ -120,7 +121,7 @@ class Course extends Model implements HasMedia, Auditable, Eventable
     // Teacher relationship
     public function teacher(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'teacher_id');
+        return $this->belongsTo(User::class, 'teacher_id')->role(RoleSystem::TEACHER);
     }
 
     // Enrolled users relationship
@@ -193,10 +194,5 @@ class Course extends Model implements HasMedia, Auditable, Eventable
             ->title($this->title)
             ->start($this->start_at)
             ->end($this->end_at);
-
-
-
-
     }
-
 }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -20,6 +20,7 @@ use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
+use Filament\View\PanelsRenderHook;
 use Filament\Widgets\AccountWidget;
 use Filament\Widgets\FilamentInfoWidget;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
@@ -88,7 +89,11 @@ class AppPanelProvider extends PanelProvider
             // ->strictAuthorization()
             ->sidebarCollapsibleOnDesktop()
             ->spa(hasPrefetching: true)
-            ->databaseNotifications();
+            ->databaseNotifications()
+            ->renderHook(
+                PanelsRenderHook::BODY_END,
+                fn(): string => view('filament.components.quiz-in-progress-global-alert')->render()
+            );
     }
 
     /**


### PR DESCRIPTION
This pull request introduces improvements to the `Course` model and enhances the Filament panel configuration. The main changes involve refining relationships in the model and adding a global alert component to the application panel.

**Model relationship improvements:**

* Updated the `teacher()` relationship in `Course.php` to restrict it to users with the teacher role by chaining the `role(RoleSystem::TEACHER)` method.

**Filament panel enhancements:**

* Imported `Filament\View\PanelsRenderHook` in `AppPanelProvider.php` to support custom render hooks.
* Added a global render hook to the Filament panel that injects the `quiz-in-progress-global-alert` view at the end of the body, ensuring users see quiz alerts across the app.

Other minor changes include code cleanup in the `Course` model, such as removing unnecessary blank lines. [[1]](diffhunk://#diff-6aa2a3a753aacda33fba155f9b681439a74b1d7fa2c1a355c5478b1e196cae55R22) [[2]](diffhunk://#diff-6aa2a3a753aacda33fba155f9b681439a74b1d7fa2c1a355c5478b1e196cae55L196-L201)