### PR TITLE
 retrieving and displaying course tags and teachers in the `MyCourse` page

### DIFF
--- a/resources/views/filament/pages/my-course.blade.php
+++ b/resources/views/filament/pages/my-course.blade.php
@@ -83,7 +83,7 @@
                                             Tất cả giáo viên
                                         </a>
                                         @foreach($this->teachers as $teacher)
-                                            <a href="#" wire:click.prevent="filterCoursesByTeacher({{ $teacher->id }})"
+                                            <a href="#" wire:click.prevent="filterCoursesByTeacher('{{ $teacher->id }}')"
                                                 class="block px-2 py-1 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700">
                                                 {{ $teacher->name }}
                                             </a>


### PR DESCRIPTION
This pull request improves the logic for retrieving and displaying course tags and teachers in the `MyCourse` page, resulting in more efficient queries and correct aggregation of data. The changes ensure that tags and teachers are collected from all enrolled courses and displayed properly in the UI.

**Data aggregation improvements:**

* Refactored the logic for collecting tags from enrolled courses to aggregate all unique tags across courses, instead of overwriting the tags for each course. (`app/Filament/Pages/MyCourse.php`)
* Optimized teacher retrieval by collecting all unique teacher IDs from enrolled courses and fetching their information in a single query, rather than querying for each course individually. (`app/Filament/Pages/MyCourse.php`)

**UI and interaction fixes:**

* Updated the teacher filter in the Blade template to pass the teacher ID as a string, ensuring proper filtering when selecting a teacher in the UI. (`resources/views/filament/pages/my-course.blade.php`)

**Code organization:**

* Added missing blank lines for readability and consistency in the `mount` and `filterCoursesByTeacher` methods. (`app/Filament/Pages/MyCourse.php`) [[1]](diffhunk://#diff-7148aa9218b856c11b64446fb0fff62b5fe8451eea39811ee7a34a919ff50bacR34) [[2]](diffhunk://#diff-7148aa9218b856c11b64446fb0fff62b5fe8451eea39811ee7a34a919ff50bacR256-L252)