### PR TITLE
updates the logic for determining MyCalendarWidget

### DIFF
--- a/app/Filament/Widgets/MyCalendarWidget.php
+++ b/app/Filament/Widgets/MyCalendarWidget.php
@@ -51,7 +51,7 @@ class MyCalendarWidget extends CalendarWidget
                     ->exists();
                 // Kiểm tra điều kiện hiển thị event
                 if (!$hasAttempt && $quiz->status == QuizStatus::PUBLISHED && $quiz->pivot->end_at >= $now && $quiz->pivot->end_at->between($now, $twoMonthsLater)) {
-                    $isUpcoming = $quiz->pivot->start_at > $now && $quiz->pivot->end_at < $now;
+                    $isUpcoming = $quiz->pivot->start_at > $now && $quiz->pivot->end_at > $now;
                     $key = $quiz->id . '-' . $course->id;
                     $events->push(
                         CalendarEvent::make($quiz)
@@ -89,7 +89,7 @@ class MyCalendarWidget extends CalendarWidget
                     ->exists();
                 // Kiểm tra điều kiện hiển thị event
                 if (!$hasSubmission && $assignment->status == AssignmentStatus::PUBLISHED && $assignment->pivot->end_at >= $now && $assignment->pivot->end_at->between($now, $twoMonthsLater)) {
-                    $isUpcoming = $assignment->pivot->start_at > $now && $assignment->pivot->end_at < $now;
+                    $isUpcoming = $assignment->pivot->start_at > $now && $assignment->pivot->end_at > $now;
 
                     $events->push(
                         CalendarEvent::make($assignment)

--- a/app/Filament/Widgets/MyCalendarWidget.php
+++ b/app/Filament/Widgets/MyCalendarWidget.php
@@ -51,7 +51,7 @@ class MyCalendarWidget extends CalendarWidget
                     ->exists();
                 // Kiểm tra điều kiện hiển thị event
                 if (!$hasAttempt && $quiz->status == QuizStatus::PUBLISHED && $quiz->pivot->end_at >= $now && $quiz->pivot->end_at->between($now, $twoMonthsLater)) {
-                    $isUpcoming = $quiz->pivot->start_at < $now && $quiz->pivot->end_at < $now;
+                    $isUpcoming = $quiz->pivot->start_at > $now && $quiz->pivot->end_at < $now;
                     $key = $quiz->id . '-' . $course->id;
                     $events->push(
                         CalendarEvent::make($quiz)
@@ -89,7 +89,7 @@ class MyCalendarWidget extends CalendarWidget
                     ->exists();
                 // Kiểm tra điều kiện hiển thị event
                 if (!$hasSubmission && $assignment->status == AssignmentStatus::PUBLISHED && $assignment->pivot->end_at >= $now && $assignment->pivot->end_at->between($now, $twoMonthsLater)) {
-                    $isUpcoming = $assignment->pivot->start_at > $now && $assignment->pivot->end_at > $now;
+                    $isUpcoming = $assignment->pivot->start_at > $now && $assignment->pivot->end_at < $now;
 
                     $events->push(
                         CalendarEvent::make($assignment)


### PR DESCRIPTION
This pull request updates the logic for determining if a quiz is considered "upcoming" in the `getEvents` method of the `MyCalendarWidget`. The change corrects the condition to ensure that only quizzes with both `start_at` and `end_at` dates in the future are marked as upcoming.

Event display logic update:

* Updated the `$isUpcoming` condition in the `getEvents` method of `MyCalendarWidget.php` to check that both `start_at` and `end_at` are greater than the current time, ensuring only future quizzes are marked as upcoming.