### PR TITLE
replacing the old quiz notification

### DIFF
--- a/app/Filament/Pages/MyQuiz.php
+++ b/app/Filament/Pages/MyQuiz.php
@@ -710,7 +710,7 @@ class MyQuiz extends Page
 
             // Update attempt
             $this->currentAttempt->update([
-                'status' => QuizAttemptStatus::COMPLETED->value,
+                'status' => QuizAttemptStatus::COMPLETED,
                 'end_at' => now(),
                 'points' => $totalScore,
                 'max_points' => $maxScore,

--- a/app/Livewire/QuizInProgressAlert.php
+++ b/app/Livewire/QuizInProgressAlert.php
@@ -2,11 +2,9 @@
 
 namespace App\Livewire;
 
-use App\Enums\Status\QuizAttemptStatus;
-use App\Models\QuizAttempt;
-use Filament\Notifications\Notification;
-use Filament\Actions\Action;
+use App\Services\QuizFilamentNotificationService;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
 use Livewire\Component;
 
 class QuizInProgressAlert extends Component
@@ -24,80 +22,25 @@ class QuizInProgressAlert extends Component
             return;
         }
 
-        if (session()->get('dismissed_quiz_notification_' . Auth::id())) {
-            return;
+        // Kiểm tra xem có đang ở trang quiz-taking không
+        if ($this->isOnQuizTakingPage()) {
+            return; // Không hiển thị notification khi đang làm bài
         }
 
-        $attempts = QuizAttempt::with('quiz')
-            ->where('student_id', Auth::id())
-            ->where('status', QuizAttemptStatus::IN_PROGRESS)
-            ->get();
-
-        $orphanedAttempts = $attempts->whereNull('quiz');
-        if ($orphanedAttempts->isNotEmpty()) {
-            QuizAttempt::whereIn('id', $orphanedAttempts->pluck('id'))
-                ->update(['status' => QuizAttemptStatus::ABANDONED]);
-        }
-
-        $validAttempts = $attempts->whereNotNull('quiz');
-
-        if ($validAttempts->isNotEmpty() && $this->shouldShowNotification() && !$this->hasSentThisPageLoad) {
-            $this->showFilamentNotification($validAttempts);
+        if (!$this->hasSentThisPageLoad) {
+            $notificationService = app(QuizFilamentNotificationService::class);
+            $notificationService->sendInProgressNotifications();
             $this->hasSentThisPageLoad = true;
         }
     }
 
-    public function dismissNotification(): void
+    /**
+     * Kiểm tra xem có đang ở trang quiz-taking không
+     */
+    private function isOnQuizTakingPage(): bool
     {
-        session()->put('dismissed_quiz_notification_' . Auth::id(), true);
-    }
-
-    public function showFilamentNotification($attempts): void
-    {
-        $count = $attempts->count();
-        $notificationId = 'quiz_in_progress_' . Auth::id();
-
-        $notificationBuilder = Notification::make($notificationId)
-            ->warning()
-            ->persistent();
-
-        if ($count === 1) {
-            $attempt = $attempts->first();
-            $startedAt = \Carbon\Carbon::parse($attempt->start_at)->format('d/m/Y H:i');
-
-            $notificationBuilder
-                ->title('Bạn đang làm dở quiz')
-                ->body("Quiz: {$attempt->quiz->title}\nBắt đầu: {$startedAt}")
-                ->actions([
-                    Action::make('continue')
-                        ->label('Tiếp tục làm bài')
-                        ->button()
-                        ->url(route('filament.app.pages.quiz-taking', ['quiz' => $attempt->quiz_id])),
-
-                ]);
-        } else {
-            $quizTitles = $attempts->pluck('quiz.title')->take(3)->implode(', ');
-            $moreText = $count > 3 ? "... và " . ($count - 3) . " quiz khác" : "";
-
-            $notificationBuilder
-                ->title("Bạn đang làm dở {$count} quiz")
-                ->body("Các quiz: {$quizTitles}{$moreText}")
-                ->actions([
-                    Action::make('view_all')
-                        ->label('Xem tất cả')
-                        ->button()
-                        ->url(route('filament.app.pages.my-quiz')),
-
-                ]);
-        }
-
-        $notificationBuilder->send();
-    }
-
-    public function shouldShowNotification(): bool
-    {
-        $currentUrl = request()->url();
-        return !str_contains($currentUrl, '/quiz-taking') && !str_contains($currentUrl, '/my-quiz');
+        $currentRoute = Route::currentRouteName();
+        return $currentRoute === 'filament.app.pages.quiz-taking';
     }
 
     public function render()

--- a/app/Notifications/QuizInProgressNotification.php
+++ b/app/Notifications/QuizInProgressNotification.php
@@ -8,6 +8,10 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\DatabaseMessage;
 use Illuminate\Notifications\Notification;
 
+/**
+ * @deprecated Không còn sử dụng - đã chuyển sang QuizFilamentNotificationService
+ * Class này được giữ lại để tránh lỗi nếu có database notifications cũ
+ */
 class QuizInProgressNotification extends Notification implements ShouldQueue
 {
     use Queueable;

--- a/app/Services/QuizFilamentNotificationService.php
+++ b/app/Services/QuizFilamentNotificationService.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\Status\QuizAttemptStatus;
+use App\Models\QuizAttempt;
+use App\Models\User;
+use Carbon\Carbon;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+class QuizFilamentNotificationService
+{
+    /**
+     * Gửi thông báo nhắc nhở về các bài quiz đang làm dở.
+     * Đây là phương thức chính, tự động xử lý trường hợp 1 hoặc nhiều quiz.
+     */
+    public function sendInProgressNotifications(): void
+    {
+        if (!Auth::check()) {
+            return;
+        }
+
+        $user = Auth::user();
+
+        // Lấy tất cả các lần làm bài đang dang dở của user
+        // Eager load 'quiz' để tránh truy vấn N+1
+        $inProgressAttempts = QuizAttempt::with('quiz')
+            ->where('student_id', $user->id)
+            ->where('status', QuizAttemptStatus::IN_PROGRESS)
+            ->whereHas('quiz') // Chỉ lấy những attempt có quiz còn tồn tại
+            ->get();
+
+        // Dọn dẹp trước: Xóa tất cả các thông báo quiz cũ
+        $this->clearAllInProgressNotificationsForUser($user);
+
+        $count = $inProgressAttempts->count();
+
+        if ($count === 0) {
+            // Nếu không có bài nào, đảm bảo không còn thông báo nào sót lại
+            return;
+        }
+
+        // Tự động gọi phương thức phù hợp dựa trên số lượng
+        if ($count === 1) {
+            $this->sendSingleNotification($user, $inProgressAttempts->first());
+        } else {
+            $this->sendMultipleNotification($user, $inProgressAttempts);
+        }
+    }
+
+    /**
+     * Gửi thông báo cho một QuizAttempt cụ thể (được gọi từ Observer).
+     * Phương thức này sẽ gọi lại logic chính để đảm bảo thông báo được cập nhật đúng.
+     */
+    public function sendInProgressNotification(QuizAttempt $quizAttempt): void
+    {
+        // Gọi lại phương thức chính để xử lý tất cả các thông báo
+        $this->sendInProgressNotifications();
+    }
+
+    /**
+     * Xóa thông báo cho một lần làm bài cụ thể khi nó hoàn thành hoặc bị hủy.
+     * Sau khi xóa, sẽ kiểm tra và gửi lại thông báo tổng hợp nếu cần.
+     */
+    public function clearNotificationForAttempt(int $attemptId): void
+    {
+        if (!Auth::check()) {
+            return;
+        }
+
+        $user = Auth::user();
+        $notificationId = 'quiz_in_progress_' . $attemptId;
+
+        // Xóa thông báo cho attempt cụ thể này
+        $deletedCount = $this->deleteNotificationById($user, $notificationId);
+
+        Log::info('Cleared notification for a specific attempt', [
+            'user_id' => $user->id,
+            'attempt_id' => $attemptId,
+            'count' => $deletedCount
+        ]);
+
+        // Sau khi xóa một thông báo, hãy chạy lại logic chính để đảm bảo
+        // hệ thống hiển thị đúng thông báo tổng hợp cho các quiz còn lại.
+        $this->sendInProgressNotifications();
+    }
+
+    // =========================================================================
+    // Private Helper Methods (Các phương thức hỗ trợ)
+    // =========================================================================
+
+    /**
+     * Gửi thông báo cho TRƯỜNG HỢP CÓ 1 QUIZ dang dở.
+     */
+    private function sendSingleNotification(User $user, QuizAttempt $attempt): void
+    {
+        $notificationId = 'quiz_in_progress_' . $attempt->id;
+        $startedAt = Carbon::parse($attempt->start_at)->format('d/m/Y H:i');
+
+        Notification::make($notificationId)
+            ->warning()
+            ->title('Bạn đang làm dở bài quiz')
+            ->body("Quiz: {$attempt->quiz->title}\nBắt đầu lúc: {$startedAt}")
+            ->actions([
+                Action::make('continue')
+                    ->label('Tiếp tục làm bài')
+                    ->button()
+                    ->url(route('filament.app.pages.quiz-taking', ['quiz' => $attempt->quiz_id])),
+                Action::make('dismiss')->label('Bỏ qua')->button()->color('gray')->close(),
+            ])
+            ->persistent() // Thông báo sẽ không tự biến mất
+            ->sendToDatabase($user);
+
+        Log::info('Sent single in-progress notification', ['user_id' => $user->id, 'attempt_id' => $attempt->id]);
+    }
+
+    /**
+     * Gửi thông báo cho TRƯỜNG HỢP CÓ NHIỀU QUIZ dang dở.
+     */
+    private function sendMultipleNotification(User $user, $attempts): void
+    {
+        $count = $attempts->count();
+        $notificationId = 'quiz_in_progress_multiple_' . $user->id;
+
+        // Lấy 3 tiêu đề đầu tiên để hiển thị
+        $quizTitles = $attempts->pluck('quiz.title')->take(3)->implode(', ');
+        $moreText = $count > 3 ? "... và " . ($count - 3) . " bài khác" : "";
+
+        Notification::make($notificationId)
+            ->warning()
+            ->title("Bạn có {$count} bài quiz đang dang dở")
+            ->body("Bao gồm: {$quizTitles}{$moreText}")
+            ->actions([
+                Action::make('view_all')
+                    ->label('Xem các bài làm')
+                    ->button()
+                    ->url(route('filament.app.pages.my-quiz')), // Chuyển hướng đến trang danh sách
+                Action::make('dismiss')->label('Bỏ qua')->button()->color('gray')->close(),
+            ])
+            ->persistent() // Thông báo sẽ không tự biến mất
+            ->sendToDatabase($user);
+
+        Log::info('Sent multiple in-progress notification', ['user_id' => $user->id, 'count' => $count]);
+    }
+
+    /**
+     * Dọn dẹp TẤT CẢ các thông báo về quiz đang dang dở của một user.
+     * Được gọi trước khi gửi thông báo mới để tránh trùng lặp.
+     */
+    private function clearAllInProgressNotificationsForUser(User $user): void
+    {
+        $deletedCount = $user->notifications()
+            ->where('type', 'Filament\\Notifications\\DatabaseNotification')
+            ->where(function ($query) use ($user) {
+                $query->where('data->id', 'like', 'quiz_in_progress_%');
+            })
+            ->delete();
+
+        if ($deletedCount > 0) {
+            Log::info('Cleared all in-progress notifications for user', [
+                'user_id' => $user->id,
+                'count' => $deletedCount
+            ]);
+        }
+    }
+
+    /**
+     * Xóa một notification cụ thể dựa trên ID của nó.
+     */
+    private function deleteNotificationById(User $user, string $notificationId): int
+    {
+        return $user->notifications()
+            ->where('type', 'Filament\\Notifications\\DatabaseNotification')
+            ->where('data->id', $notificationId)
+            ->delete();
+    }
+}

--- a/app/Services/QuizService.php
+++ b/app/Services/QuizService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\Status\QuizAttemptStatus;
 use App\Exceptions\Services\QuizServiceException;
 use App\Models\Question;
 use App\Models\Quiz;
@@ -415,7 +416,7 @@ class QuizService extends BaseService implements QuizServiceInterface
                     // Update attempt
                     $this->quizAttemptRepository->updateById($attemptId, [
                         'points' => $score,
-                        'status' => 'completed',
+                        'status' => QuizAttemptStatus::COMPLETED,
                         'end_at' => Carbon::now(),
                         'answers' => $answersJson,
                     ]);

--- a/resources/views/filament/pages/quiz-taking.blade.php
+++ b/resources/views/filament/pages/quiz-taking.blade.php
@@ -237,28 +237,6 @@
                     <div
                         class="lg:hidden bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4">
                         <div class="space-y-3">
-                            <div class="flex items-center justify-between mb-3">
-                                <div class="text-sm text-gray-600 dark:text-gray-400">
-                                    <span class="font-medium text-gray-900 dark:text-white">Tiến độ:</span>
-                                    <span
-                                        class="ml-1 font-semibold text-blue-600 dark:text-blue-400">{{ $this->answeredCount }}</span>
-                                    <span class="text-gray-500 dark:text-gray-400">/</span>
-                                    <span
-                                        class="font-semibold text-gray-700 dark:text-gray-300">{{ $this->totalQuestions }}</span>
-                                    <span class="text-gray-500 dark:text-gray-400">câu</span>
-                                </div>
-                                <div class="text-xs px-2 py-1 rounded-full
-                                    @if($this->progressPercentage >= 100)
-                                        bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300
-                                    @elseif($this->progressPercentage >= 50)
-                                        bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300
-                                    @else
-                                        bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400
-                                    @endif">
-                                    {{ $this->progressPercentage }}%
-                                </div>
-                            </div>
-
                             <div class="flex items-center justify-between gap-4">
                                 {{ $this->customSubmitAction }}
 
@@ -398,6 +376,8 @@
     @endif
 
     <script>
+
+
         // Javascript không thay đổi
         function quizTakingApp() {
                 return {
@@ -512,7 +492,6 @@
                                 // Use requestAnimationFrame for smooth UI updates
                                 requestAnimationFrame(() => {
                                     this.$wire.set('answers', answers, false);
-                                    this.updateProgressFromStorage(answers);
                                 });
                             } catch (e) {
                                 console.error('Error loading saved answers:', e);
@@ -523,19 +502,7 @@
                         this.loadCurrentQuestionIndex();
                     },
 
-                    updateProgressFromStorage(answers) {
-                        const totalQuestions = {{ $this->quizModel->questions->count() }};
-                        const answeredCount = Object.values(answers).filter(a => Array.isArray(a) ? a.length > 0 : a !== null).length;
-                        const percentage = totalQuestions > 0 ? Math.round((answeredCount / totalQuestions) * 100) : 0;
 
-                        const progressBar = document.querySelector('.bg-blue-500');
-                        const progressText = document.querySelector('.text-gray-600');
-                        const progressPercentage = document.querySelector('.font-semibold');
-
-                        if (progressBar) progressBar.style.width = percentage + '%';
-                        if (progressText) progressText.textContent = `Tiến độ: ${answeredCount}/${totalQuestions} câu`;
-                        if (progressPercentage) progressPercentage.textContent = percentage + '%';
-                    },
 
                     bindAnswerEvents() {
                         this.$watch('$wire.answers', (newAnswers) => {
@@ -547,7 +514,6 @@
                     saveToStorage(answers) {
                         const storageKey = `quiz_${this.quizId}_attempt_${this.attemptId}`;
                         localStorage.setItem(storageKey, JSON.stringify(answers));
-                        this.updateProgressFromStorage(answers);
                     },
 
                     saveCurrentQuestionIndex() {


### PR DESCRIPTION
This pull request refactors the quiz in-progress notification system, replacing the old notification logic with a new service (`QuizFilamentNotificationService`) that leverages Filament notifications for improved handling and user experience. The changes centralize notification logic, remove legacy code, and ensure notifications are managed more reliably and efficiently across the application.

**Notification System Refactor**

* Introduced `QuizFilamentNotificationService`, which manages all quiz in-progress notifications, including sending, updating, and clearing notifications for both single and multiple quiz attempts. This service replaces the previous notification logic and database notification class.
* Refactored `QuizInProgressAlert` Livewire component to delegate notification logic to the new service, removing legacy methods and simplifying checks for when notifications should be shown. [[1]](diffhunk://#diff-44c4efe8844b8d4501fca619f743e4e752486404a9fa82512fed58d586843afcL5-R7) [[2]](diffhunk://#diff-44c4efe8844b8d4501fca619f743e4e752486404a9fa82512fed58d586843afcL27-R43)
* Updated `QuizAttemptObserver` to use `QuizFilamentNotificationService` for sending and removing notifications, and added debug logging for status changes and notification actions. [[1]](diffhunk://#diff-84717f082c5fffc8b7979e1b42eb3ecbe17117d820240beac2080050f19b9d90L7-R15) [[2]](diffhunk://#diff-84717f082c5fffc8b7979e1b42eb3ecbe17117d820240beac2080050f19b9d90R32-R48) [[3]](diffhunk://#diff-84717f082c5fffc8b7979e1b42eb3ecbe17117d820240beac2080050f19b9d90L44-R68)
* Deprecated the old `QuizInProgressNotification` class, marking it for removal in the future and clarifying its purpose for legacy database notifications.
* Updated `QuizNotificationService` to use the new service for sending and clearing notifications, removing manual notification management and legacy code. [[1]](diffhunk://#diff-82044f1888279b88b421cbb673e7ae7ca08d0bdc8c5c9a857be8f5cdaa261e39L8-R9) [[2]](diffhunk://#diff-82044f1888279b88b421cbb673e7ae7ca08d0bdc8c5c9a857be8f5cdaa261e39L18-R21) [[3]](diffhunk://#diff-82044f1888279b88b421cbb673e7ae7ca08d0bdc8c5c9a857be8f5cdaa261e39L44-R43)

**Quiz Attempt Status Consistency**

* Changed quiz attempt status assignments throughout the codebase to use the `QuizAttemptStatus::COMPLETED` enum instead of string literals, ensuring consistency and type safety. [[1]](diffhunk://#diff-97daa3cd0b189d333f5b8b202ba82f365afef951096b481af28a8895d5671e8fL713-R713) [[2]](diffhunk://#diff-938fe0e1440f68de2a64fd86360346812f85d0162d6197f4488907b0204bdfdaL418-R419)

**UI and Miscellaneous**

* Minor UI cleanup in the quiz-taking Blade view, removing unused progress bar elements and streamlining the display.
* Removed unnecessary JavaScript code for progress updates, reflecting the streamlined notification logic.

These changes together provide a more robust and maintainable notification experience for users taking quizzes.