### PR TITLE
Remove searchable from ID columns in relation managers

### DIFF
--- a/app/Filament/Resources/Courses/RelationManagers/ManagersRelationManager.php
+++ b/app/Filament/Resources/Courses/RelationManagers/ManagersRelationManager.php
@@ -59,7 +59,6 @@ class ManagersRelationManager extends RelationManager
                     ->toggleable(),
                 TextColumn::make('id')
                     ->label(__('resource_user.table.columns.id'))
-                    ->searchable()
                     ->copyable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('name')

--- a/app/Filament/Resources/Courses/RelationManagers/QuizzesRelationManager.php
+++ b/app/Filament/Resources/Courses/RelationManagers/QuizzesRelationManager.php
@@ -49,7 +49,6 @@ class QuizzesRelationManager extends RelationManager
                 TextColumn::make('id')
                     ->label('ID')
                     ->copyable()
-                    ->searchable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('title')
                     ->searchable(),

--- a/app/Filament/Resources/Courses/RelationManagers/StudentsRelationManager.php
+++ b/app/Filament/Resources/Courses/RelationManagers/StudentsRelationManager.php
@@ -53,7 +53,6 @@ class StudentsRelationManager extends RelationManager
                     ->toggleable(),
                 TextColumn::make('id')
                     ->label(__('resource_user.table.columns.id'))
-                    ->searchable()
                     ->copyable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('name')
@@ -105,7 +104,7 @@ class StudentsRelationManager extends RelationManager
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->schema(fn (AttachAction $action): array => [
+                    ->schema(fn(AttachAction $action): array => [
                         $action->getRecordSelect(),
                         ...$this->getTimeCoursePicker(),
                     ])

--- a/app/Filament/Resources/Quizzes/RelationManagers/QuestionsRelationManager.php
+++ b/app/Filament/Resources/Quizzes/RelationManagers/QuestionsRelationManager.php
@@ -56,7 +56,6 @@ class QuestionsRelationManager extends RelationManager
                 TextColumn::make('id')
                     ->label('ID')
                     ->copyable()
-                    ->searchable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('title')
                     ->searchable(),
@@ -81,7 +80,7 @@ class QuestionsRelationManager extends RelationManager
                 CreateAction::make(),
                 AttachAction::make()
                     // ->multiple()
-                    ->schema(fn (AttachAction $action) => [
+                    ->schema(fn(AttachAction $action) => [
                         $action->getRecordSelect(),
                         ModalTableSelect::make('recordId')
                             ->label('Question')

--- a/app/Filament/Resources/Users/RelationManagers/CoursesRelationManager.php
+++ b/app/Filament/Resources/Users/RelationManagers/CoursesRelationManager.php
@@ -32,7 +32,6 @@ class CoursesRelationManager extends RelationManager
             ->columns([
                 TextColumn::make('id')
                     ->label('ID')
-                    ->searchable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('title')
                     ->searchable(),


### PR DESCRIPTION
The 'searchable' attribute was removed from 'id' columns in several Filament relation manager tables to prevent searching by ID. This change improves table usability by focusing search functionality on more relevant fields.